### PR TITLE
Workaround for `schedule` not supporting inputs

### DIFF
--- a/.github/workflows/crawler_benchmarks.yaml
+++ b/.github/workflows/crawler_benchmarks.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       crawler_name_pattern:
         description: Run only crawlers that are in folders whose name matches this pattern
-        required: true
+        required: false
         type: string
         default: .*(cheerio)|(parsel).*
       crawler_input:
@@ -24,47 +24,17 @@ on:
         type: string
         default: manual
 
-  schedule:
-    - cron: '0 0 * * *'
-      inputs:
-        crawler_name_pattern:
-          required: true
-          type: string
-          default: .*(cheerio)|(parsel).*
-        crawler_input:
-          required: false
-          type: string
-          default: >
-            {
-            "startUrls":[{"url":"https://warehouse-theme-metal.myshopify.com/"}],
-            "exclude":[],
-            "proxyConfiguration":{"useApifyProxy": true,"apifyProxyGroups":["SHADER"],"apifyProxyCountry":"US"}
-            }
-        tag:
-          required: false
-          type: string
-          default: daily-master
-
-    - cron: '0 2 * * *'
-      inputs:
-        crawler_name_pattern:
-          required: true
-          type: string
-          default: .*playwright.*
-        crawler_input:
-          required: false
-          type: string
-          default: >
-            {
-            "startUrls":[{"url":"https://warehouse-theme-metal.myshopify.com/"}],
-            "exclude":["https://**/products/**"],
-            "proxyConfiguration":{"useApifyProxy": true,"apifyProxyGroups":["SHADER"],"apifyProxyCountry":"US"}
-            }
-        tag:
-          required: false
-          type: string
-          default: daily-master
-
+  workflow_call:
+    inputs:
+      crawler_name_pattern:
+        required: false
+        type: string
+      crawler_input:
+        required: false
+        type: string
+      tag:
+        required: false
+        type: string
 
 jobs:
   crawler_benchmarks:

--- a/.github/workflows/crawler_benchmarks_cron.yaml
+++ b/.github/workflows/crawler_benchmarks_cron.yaml
@@ -1,0 +1,36 @@
+name: Crawler benchmarks cron
+# Workaround for `schedule` not supporting input parameters.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+  workflow_dispatch:
+
+jobs:
+  jobs:
+    http-crawlers:
+      name: Http crawlers benchmarks
+      uses: .github/workflows/crawler_benchmarks.yaml
+      with:
+        crawler_name_pattern: .*playwright.*
+        crawler_input: >
+          {
+          "startUrls":[{"url":"https://warehouse-theme-metal.myshopify.com/"}],
+          "exclude":[],
+          "proxyConfiguration":{"useApifyProxy": true,"apifyProxyGroups":["SHADER"],"apifyProxyCountry":"US"}
+          }
+        tag: daily-master
+
+    playwright-crawlers:
+      name: Playwright crawlers benchmarks
+      uses: .github/workflows/crawler_benchmarks.yaml
+      with:
+        crawler_name_pattern: .*(cheerio)|(parsel).*
+        crawler_input: >
+          {
+          "startUrls":[{"url":"https://warehouse-theme-metal.myshopify.com/"}],
+          "exclude":["https://**/products/**"],
+          "proxyConfiguration":{"useApifyProxy": true,"apifyProxyGroups":["SHADER"],"apifyProxyCountry":"US"}
+          }
+        tag: daily-master


### PR DESCRIPTION
Trigger scheduled benchmarks from another workflow to allow passing input parameters