### PR TITLE
Change to 2 links per page to avoid bombing RQ during the benchmark test

### DIFF
--- a/benchmark_server_js/test_server.js
+++ b/benchmark_server_js/test_server.js
@@ -5,14 +5,14 @@ const PORT = 8080;
 
 const args = process.argv.slice(2);
 // The only argument controls to which depth level the links to next level are generated
-const DEPTH_LEVEL = parseInt(args[0]) || 10;
+const DEPTH_LEVEL = parseInt(args[0]) || 33;
 
 // Function to generate HTML response
 function generateHtmlResponse(path) {
     let links = '';
     if (path.length !== DEPTH_LEVEL) {
         // Generate links based on the level
-        links = Array.from({ length: 10 }, (_, i) => `<a href="${path}${i}">${path}${i}</a>`).join('\n');
+        links = Array.from({ length: 2 }, (_, i) => `<a href="${path}${i}">${path}${i}</a>`).join('\n');
     }
 
     return `


### PR DESCRIPTION
Instead of having test server with 10 links per page from 0 to ten , have 2 links per page from 0 to 1.

Links before: /012414541...
Links now: /0111101110...

The reason is to avoid bombing the RQ during the benchmark, where the crawler is enqueuing way more requests than it is crawling.